### PR TITLE
Date Comparisons

### DIFF
--- a/__tests__/Expression.test.ts
+++ b/__tests__/Expression.test.ts
@@ -10,6 +10,7 @@ import {
     ValueExpression
 } from '../src/NCalc/Domain/index';
 import {EvaluateOptions} from '../src/NCalc/EvaluationOptions';
+import dayjs from "dayjs";
 
 describe('Expressions', () => {
     test('ShouldCache', () => {
@@ -460,6 +461,8 @@ describe('Expressions', () => {
     test('ShouldCompareDates', () => {
         expect(new Expression('#1/1/2009#==#1/1/2009#').Evaluate()).toBe(true);
         expect(new Expression('#2/1/2009#==#1/1/2009#').Evaluate()).toBe(false);
+        expect(new Expression('#2/1/2009#>#1/1/2009#').Evaluate()).toBe(true);
+        expect(new Expression('#2/1/2009#<#1/1/2009#').Evaluate()).toBe(false);
     });
 
     // @todo

--- a/src/Grammar/NCalc.g4
+++ b/src/Grammar/NCalc.g4
@@ -195,7 +195,7 @@ value
 	| INTEGER { try { $val = new ValueExpression(parseInt($INTEGER.text), ValueType.Integer); } catch(e) { $val = new ValueExpression(parseFloat($INTEGER.text), ValueType.Float); } 
 		} // @todo support bigint
 	| STRING { $val = new ValueExpression(this.ExtractString($STRING.text), ValueType.String); }
-	| DATETIME { $val = new ValueExpression(dayjs($DATETIME.text.substring(1, $DATETIME.text.length-2)).toString(), ValueType.DateTime); 
+	| DATETIME { $val = new ValueExpression(dayjs($DATETIME.text.substring(1, $DATETIME.text.length-1)).format(), ValueType.DateTime);
 		}
 	| TRUE { $val = new ValueExpression(true, ValueType.Boolean); }
 	| FALSE { $val = new ValueExpression(false, ValueType.Float); };

--- a/src/Grammar/NCalcLexer.ts
+++ b/src/Grammar/NCalcLexer.ts
@@ -1,4 +1,4 @@
-// Generated from NCalc.g4 by ANTLR 4.12.0
+// Generated from src/Grammar/NCalc.g4 by ANTLR 4.13.1
 // noinspection ES6UnusedImports,JSUnusedGlobalSymbols,JSUnusedLocalSymbols
 import {
 	ATN,
@@ -56,29 +56,43 @@ export default class NCalcLexer extends Lexer {
 	public static readonly EOF = Token.EOF;
 
 	public static readonly channelNames: string[] = [ "DEFAULT_TOKEN_CHANNEL", "HIDDEN" ];
-	public static readonly literalNames: string[] = [ null, "'?'", "':'", "'&&'", 
-                                                   "'||'", "'&'", "'|'", 
-                                                   "'^'", "'=='", "'='", 
-                                                   "'!='", "'<>'", "'<'", 
-                                                   "'<='", "'>'", "'>='", 
-                                                   "'<<'", "'>>'", "'+'", 
-                                                   "'-'", "'*'", "'/'", 
-                                                   "'%'", "'!'", "'~'", 
-                                                   "'**'", "'('", "')'", 
-                                                   "','" ];
-	public static readonly symbolicNames: string[] = [ null, null, null, null, 
-                                                    null, null, null, null, 
-                                                    null, null, null, null, 
-                                                    null, null, null, null, 
-                                                    null, null, null, null, 
-                                                    null, null, null, null, 
-                                                    null, null, null, null, 
-                                                    null, "NOT", "TRUE", 
-                                                    "FALSE", "AND", "OR", 
-                                                    "ID", "FLOAT", "INTEGER", 
-                                                    "STRING", "DATETIME", 
-                                                    "NAME", "EXPONENT", 
-                                                    "WS" ];
+	public static readonly literalNames: (string | null)[] = [ null, "'?'", 
+                                                            "':'", "'&&'", 
+                                                            "'||'", "'&'", 
+                                                            "'|'", "'^'", 
+                                                            "'=='", "'='", 
+                                                            "'!='", "'<>'", 
+                                                            "'<'", "'<='", 
+                                                            "'>'", "'>='", 
+                                                            "'<<'", "'>>'", 
+                                                            "'+'", "'-'", 
+                                                            "'*'", "'/'", 
+                                                            "'%'", "'!'", 
+                                                            "'~'", "'**'", 
+                                                            "'('", "')'", 
+                                                            "','" ];
+	public static readonly symbolicNames: (string | null)[] = [ null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, null, 
+                                                             null, "NOT", 
+                                                             "TRUE", "FALSE", 
+                                                             "AND", "OR", 
+                                                             "ID", "FLOAT", 
+                                                             "INTEGER", 
+                                                             "STRING", "DATETIME", 
+                                                             "NAME", "EXPONENT", 
+                                                             "WS" ];
 	public static readonly modeNames: string[] = [ "DEFAULT_MODE", ];
 
 	public static readonly ruleNames: string[] = [

--- a/src/Grammar/NCalcListener.ts
+++ b/src/Grammar/NCalcListener.ts
@@ -1,4 +1,4 @@
-// Generated from NCalc.g4 by ANTLR 4.12.0
+// Generated from src/Grammar/NCalc.g4 by ANTLR 4.13.1
 
 import {ParseTreeListener} from "antlr4";
 

--- a/src/Grammar/NCalcParser.ts
+++ b/src/Grammar/NCalcParser.ts
@@ -1,4 +1,4 @@
-// Generated from NCalc.g4 by ANTLR 4.12.0
+// Generated from src/Grammar/NCalc.g4 by ANTLR 4.13.1
 // noinspection ES6UnusedImports,JSUnusedGlobalSymbols,JSUnusedLocalSymbols
 
 import {
@@ -12,6 +12,8 @@ import {
 	Interval, IntervalSet
 } from 'antlr4';
 import NCalcListener from "./NCalcListener.js";
+import NCalcVisitor from "./NCalcVisitor.js";
+
 // for running tests with parameters, TODO: discuss strategy for typed parameters in CI
 // eslint-disable-next-line no-unused-vars
 type int = number;
@@ -1074,7 +1076,7 @@ export default class NCalcParser extends Parser {
 				{
 				this.state = 243;
 				localctx._DATETIME = this.match(NCalcParser.DATETIME);
-				 localctx.val =  new ValueExpression(dayjs((localctx._DATETIME != null ? localctx._DATETIME.text : undefined).substring(1, (localctx._DATETIME != null ? localctx._DATETIME.text : undefined).length-2)).toString(), ValueType.DateTime); 
+				 localctx.val =  new ValueExpression(dayjs((localctx._DATETIME != null ? localctx._DATETIME.text : undefined).substring(1, (localctx._DATETIME != null ? localctx._DATETIME.text : undefined).length-1)).format(), ValueType.DateTime);
 						
 				}
 				break;
@@ -1411,6 +1413,14 @@ export class NcalcExpressionContext extends ParserRuleContext {
 	 		listener.exitNcalcExpression(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitNcalcExpression) {
+			return visitor.visitNcalcExpression(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -1446,6 +1456,14 @@ export class LogicalExpressionContext extends ParserRuleContext {
 	public exitRule(listener: NCalcListener): void {
 	    if(listener.exitLogicalExpression) {
 	 		listener.exitLogicalExpression(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitLogicalExpression) {
+			return visitor.visitLogicalExpression(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -1490,6 +1508,14 @@ export class ConditionalExpressionContext extends ParserRuleContext {
 	 		listener.exitConditionalExpression(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitConditionalExpression) {
+			return visitor.visitConditionalExpression(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -1518,6 +1544,14 @@ export class BooleanExpressionContext extends ParserRuleContext {
 	public exitRule(listener: NCalcListener): void {
 	    if(listener.exitBooleanExpression) {
 	 		listener.exitBooleanExpression(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitBooleanExpression) {
+			return visitor.visitBooleanExpression(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -1550,6 +1584,14 @@ export class RelationalExpressionContext extends ParserRuleContext {
 	 		listener.exitRelationalExpression(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitRelationalExpression) {
+			return visitor.visitRelationalExpression(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -1578,6 +1620,14 @@ export class ShiftExpressionContext extends ParserRuleContext {
 	public exitRule(listener: NCalcListener): void {
 	    if(listener.exitShiftExpression) {
 	 		listener.exitShiftExpression(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitShiftExpression) {
+			return visitor.visitShiftExpression(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -1610,6 +1660,14 @@ export class AdditiveExpressionContext extends ParserRuleContext {
 	 		listener.exitAdditiveExpression(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitAdditiveExpression) {
+			return visitor.visitAdditiveExpression(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -1638,6 +1696,14 @@ export class MultiplicativeExpressionContext extends ParserRuleContext {
 	public exitRule(listener: NCalcListener): void {
 	    if(listener.exitMultiplicativeExpression) {
 	 		listener.exitMultiplicativeExpression(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitMultiplicativeExpression) {
+			return visitor.visitMultiplicativeExpression(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -1675,6 +1741,14 @@ export class UnaryExpressionContext extends ParserRuleContext {
 	 		listener.exitUnaryExpression(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitUnaryExpression) {
+			return visitor.visitUnaryExpression(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -1706,6 +1780,14 @@ export class ExponentialExpressionContext extends ParserRuleContext {
 	public exitRule(listener: NCalcListener): void {
 	    if(listener.exitExponentialExpression) {
 	 		listener.exitExponentialExpression(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitExponentialExpression) {
+			return visitor.visitExponentialExpression(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -1744,6 +1826,14 @@ export class PrimaryExpressionContext extends ParserRuleContext {
 	public exitRule(listener: NCalcListener): void {
 	    if(listener.exitPrimaryExpression) {
 	 		listener.exitPrimaryExpression(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitPrimaryExpression) {
+			return visitor.visitPrimaryExpression(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -1790,6 +1880,14 @@ export class ValueContext extends ParserRuleContext {
 	 		listener.exitValue(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitValue) {
+			return visitor.visitValue(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -1818,6 +1916,14 @@ export class IdentifierContext extends ParserRuleContext {
 	public exitRule(listener: NCalcListener): void {
 	    if(listener.exitIdentifier) {
 	 		listener.exitIdentifier(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitIdentifier) {
+			return visitor.visitIdentifier(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -1856,6 +1962,14 @@ export class ExpressionListContext extends ParserRuleContext {
 	 		listener.exitExpressionList(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitExpressionList) {
+			return visitor.visitExpressionList(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -1880,6 +1994,14 @@ export class ArgumentsContext extends ParserRuleContext {
 	public exitRule(listener: NCalcListener): void {
 	    if(listener.exitArguments) {
 	 		listener.exitArguments(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: NCalcVisitor<Result>): Result {
+		if (visitor.visitArguments) {
+			return visitor.visitArguments(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }

--- a/src/Grammar/NCalcVisitor.ts
+++ b/src/Grammar/NCalcVisitor.ts
@@ -1,0 +1,122 @@
+// Generated from src/Grammar/NCalc.g4 by ANTLR 4.13.1
+
+import {ParseTreeVisitor} from 'antlr4';
+
+
+import { NcalcExpressionContext } from "./NCalcParser";
+import { LogicalExpressionContext } from "./NCalcParser";
+import { ConditionalExpressionContext } from "./NCalcParser";
+import { BooleanExpressionContext } from "./NCalcParser";
+import { RelationalExpressionContext } from "./NCalcParser";
+import { ShiftExpressionContext } from "./NCalcParser";
+import { AdditiveExpressionContext } from "./NCalcParser";
+import { MultiplicativeExpressionContext } from "./NCalcParser";
+import { UnaryExpressionContext } from "./NCalcParser";
+import { ExponentialExpressionContext } from "./NCalcParser";
+import { PrimaryExpressionContext } from "./NCalcParser";
+import { ValueContext } from "./NCalcParser";
+import { IdentifierContext } from "./NCalcParser";
+import { ExpressionListContext } from "./NCalcParser";
+import { ArgumentsContext } from "./NCalcParser";
+
+
+/**
+ * This interface defines a complete generic visitor for a parse tree produced
+ * by `NCalcParser`.
+ *
+ * @param <Result> The return type of the visit operation. Use `void` for
+ * operations with no return type.
+ */
+export default class NCalcVisitor<Result> extends ParseTreeVisitor<Result> {
+	/**
+	 * Visit a parse tree produced by `NCalcParser.ncalcExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitNcalcExpression?: (ctx: NcalcExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.logicalExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitLogicalExpression?: (ctx: LogicalExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.conditionalExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitConditionalExpression?: (ctx: ConditionalExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.booleanExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitBooleanExpression?: (ctx: BooleanExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.relationalExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationalExpression?: (ctx: RelationalExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.shiftExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitShiftExpression?: (ctx: ShiftExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.additiveExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitAdditiveExpression?: (ctx: AdditiveExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.multiplicativeExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitMultiplicativeExpression?: (ctx: MultiplicativeExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.unaryExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitUnaryExpression?: (ctx: UnaryExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.exponentialExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitExponentialExpression?: (ctx: ExponentialExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.primaryExpression`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitPrimaryExpression?: (ctx: PrimaryExpressionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.value`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitValue?: (ctx: ValueContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.identifier`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitIdentifier?: (ctx: IdentifierContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.expressionList`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitExpressionList?: (ctx: ExpressionListContext) => Result;
+	/**
+	 * Visit a parse tree produced by `NCalcParser.arguments`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitArguments?: (ctx: ArgumentsContext) => Result;
+}
+

--- a/src/NCalc/Domain/EvaluationVisitor.ts
+++ b/src/NCalc/Domain/EvaluationVisitor.ts
@@ -126,13 +126,10 @@ export class EvaluationVisitor extends LogicalExpressionVisitor {
             return 1;
         }
 
-        if (typeof a == 'number' || typeof b == 'number') {
-            if (a < b) {
-                return -1;
-            } else if (a > b) {
-                return 1;
-            }
-            return 0;
+        if (a < b) {
+            return -1;
+        } else if (a > b) {
+            return 1;
         } else {
             return a == b ? 0 : 1;
         }


### PR DESCRIPTION
This PR should fix some date related issues.
 
Adjust DateTime related grammar parts:
- use the dayjs [`format()`](https://day.js.org/docs/en/display/format) function which returns an `ISO8601` (allows for lexicographical comparison between dates)
- pass the correct substring to dayjs (previously, the last character of date strings was omitted)

Adjust evaluation logic:
- allow for inequality checks between non-numerical types