### PR TITLE
Migrate from SonarCloud action to SonarQube action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   sonarcloud:
-    name: SonarCloud
+    name: SonarQube
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,8 +17,8 @@ jobs:
         run:  npm install
       - name: Run Tests
         run:  npm run test
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,5 +10,3 @@ sonar.sources=src/
 sonar.coverage.exclusions=src/Grammar/
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
-
-sonar.host.url=http://localhost:9000

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,5 @@ sonar.sources=src/
 sonar.coverage.exclusions=src/Grammar/
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
+
+sonar.host.url=http://localhost:9000


### PR DESCRIPTION
## Description
Build is failing on outdated version of node.  Migrate from the obsolete SonarCloud action to SonarQube.  
